### PR TITLE
More permissive e-mail validation

### DIFF
--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -1069,8 +1069,7 @@ public class AddressBook {
      * @return whether arg is a valid person email
      */
     private static boolean isPersonEmailValid(String email) {
-        return email.matches("\\S+@\\S+\\.\\S+"); // email is [non-whitespace]@[non-whitespace].[non-whitespace]
-        //TODO: implement a more permissive validation
+        return email.matches("^.+@.+(\\.[^\\.]+)+$");    // email is [any]@[any, not ending in dot]
     }
 
 

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -121,11 +121,18 @@
 || 	Example: add John Doe p/98765432 e/johnd@gmail.com
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Adam Brown p/111111 e/adam@gmail.com]
-|| New person added: Adam Brown, Phone: 111111, Email: adam@gmail.com
+|| Enter command: || [Command entered:  add Valid Name p/12345 e/thisEndsInADot.]
+|| Invalid command format: add 
+|| add: Adds a person to the address book.
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 
+|| ===================================================
+|| Enter command: || [Command entered:  add Azusagawa Kaede p/111111 e/"Azusagawa Kaede"@[192.168.2.1]]
+|| New person added: Azusagawa Kaede, Phone: 111111, Email: "Azusagawa Kaede"@[192.168.2.1]
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 
 || 1 persons found!
 || ===================================================
@@ -133,7 +140,7 @@
 || New person added: Betsy Choo, Phone: 222222, Email: benchoo@nus.edu.sg
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 
 || 2 persons found!
@@ -142,7 +149,7 @@
 || New person added: Charlie Dickson, Phone: 333333, Email: charlie.d@nus.edu.sg
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
 || 
@@ -152,7 +159,7 @@
 || New person added: Dickson Ee, Phone: 444444, Email: dickson@nus.edu.sg
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
 || 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
@@ -163,7 +170,7 @@
 || New person added: Esther Potato, Phone: 555555, Email: esther@notreal.potato
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
 || 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
@@ -242,7 +249,7 @@
 || Person could not be found in address book
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
 || 	4. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato
@@ -253,14 +260,14 @@
 || Deleted Person: Esther Potato  Phone Number: 555555  Email: esther@notreal.potato
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
 || 
 || 3 persons found!
 || ===================================================
 || Enter command: || [Command entered:  delete 1]
-|| Deleted Person: Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| Deleted Person: Azusagawa Kaede  Phone Number: 111111  Email: "Azusagawa Kaede"@[192.168.2.1]
 || ===================================================
 || Enter command: || [Command entered:  list]
 || 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg

--- a/test/input.txt
+++ b/test/input.txt
@@ -26,9 +26,10 @@
   add []\[;] p/12345 e/valid@e.mail
   add Valid Name p/not_numbers e/valid@e.mail
   add Valid Name p/12345 e/notAnEmail
+  add Valid Name p/12345 e/thisEndsInADot.
 
   # should add correctly
-  add Adam Brown p/111111 e/adam@gmail.com
+  add Azusagawa Kaede p/111111 e/"Azusagawa Kaede"@[192.168.2.1]
   list
   add Betsy Choo p/222222 e/benchoo@nus.edu.sg
   list


### PR DESCRIPTION
The e-mail validation does not currently accept all valid e-mails. In particular, according to RFC 3696, e-mails such as "Fred Bloggs"@example.com, which contains whitespace, should be accepted as it is surrounded by quotes.

This change now accepts all e-mails of the form [any characters]@[any characters, the last of which is not a dot]. This is looser and allows invalid e-mails to pass, but it is better to allow some invalid e-mails to pass than to prevent someone from entering a valid e-mail. If stricter validation is needed, it may be preferable to use JavaMail which has a built-in validate() method.